### PR TITLE
Add support for JWT authentication via cookies

### DIFF
--- a/pkg/services/contexthandler/auth_jwt.go
+++ b/pkg/services/contexthandler/auth_jwt.go
@@ -3,10 +3,9 @@ package contexthandler
 import (
 	"errors"
 	"fmt"
+	"github.com/jmespath/go-jmespath"
 	"net/http"
 	"strings"
-
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/grafana/grafana/pkg/login"
 	"github.com/grafana/grafana/pkg/models/roletype"
@@ -31,6 +30,14 @@ func (h *ContextHandler) initContextWithJWT(ctx *contextmodel.ReqContext, orgId 
 	jwtToken := ctx.Req.Header.Get(h.Cfg.JWTAuthHeaderName)
 	if jwtToken == "" && h.Cfg.JWTAuthURLLogin {
 		jwtToken = ctx.Req.URL.Query().Get("auth_token")
+	}
+	if jwtToken == "" {
+		cookie, err := ctx.Req.Cookie("__Secure-access_token")
+		if err == nil {
+			jwtToken = cookie.Value
+		} else {
+			ctx.Logger.Warn("Failed to get JWT token from cookie", "error", err)
+		}
 	}
 
 	if jwtToken == "" {


### PR DESCRIPTION
Grafana supports JWT-based authentication using the auth_token query parameter and the Authorization: Bearer header. However, our SSO implementation on the development server delivers the JWT token via a cookie.

When Grafana is embedded in an iframe, the query parameter and header approaches are often unavailable due to browser security restrictions or embedding limitations. As a result, users may not be authenticated properly in embedded contexts.

This PR supports reading the JWT token from a cookie as a fallback mechanism. If neither the Authorization header nor the auth_token query parameter is present, Grafana will attempt to extract the token from a configurable cookie.

This change ensures seamless JWT authentication in environments where token injection into headers or URLs isn't possible, such as iframe usage with cookie-based SSO.